### PR TITLE
Use 'with' statement to close file immediately and fixed grader.

### DIFF
--- a/template/graderCpp.py
+++ b/template/graderCpp.py
@@ -1,4 +1,4 @@
-import io, json, os
+import json, os
 import plutils
 
 test_code_coucou='''
@@ -80,11 +80,13 @@ def compile_and_run(code, input=""):
         log['compile_std_out'] = f.read()
 
     if not log['compile_err']:
-        with io.open("stdin", "w") as f:
+        with open("stdin", "w") as f:
             f.write(input)
         log['err'] = os.system("./code < stdin 2> stderr.log > stdout.log")
-        log['std_err'] = open("stderr.log", "r").read()
-        log['std_out'] = open("stdout.log", "r").read()
+        with open("stderr.log", "r") as f:
+            log['std_err'] = f.read()
+        with open("stdout.log", "r") as f:
+            log['std_out'] = f.read()
     return log
 
 def equal_out(a, b):  # Should use plutils.check_output instead

--- a/template/graderCpp.py
+++ b/template/graderCpp.py
@@ -69,15 +69,19 @@ def compile_and_run(code, input=""):
         True
     """
     log = {'code': code}
-    io.open("code.cpp", "w").write(code)
+    with open("code.cpp", "w") as f :
+        f.write(code)
     gcc_cmd = "g++ -Wall -Wno-sign-compare -Wno-unused-value -pedantic -std=c++11 " + "code.cpp -o code"
     log['compile_err'] = os.system(gcc_cmd + "> compilCstdout.log 2> compilCstderr.log ")
     # Get back the standard/error output of compilation
-    log['compile_std_err'] = open("compilCstderr.log", "r").read()
-    log['compile_std_out'] = open("compilCstdout.log", "r").read()
+    with open("compilCstderr.log", "r") as f:
+        log['compile_std_err'] = f.read()
+    with open("compilCstdout.log", "r") as f:
+        log['compile_std_out'] = f.read()
 
     if not log['compile_err']:
-        io.open("stdin", "w").write(input)
+        with io.open("stdin", "w") as f:
+            f.write(input)
         log['err'] = os.system("./code < stdin 2> stderr.log > stdout.log")
         log['std_err'] = open("stderr.log", "r").read()
         log['std_out'] = open("stdout.log", "r").read()

--- a/template/wims.pl
+++ b/template/wims.pl
@@ -38,7 +38,7 @@ if __name__ == "__main__":
     else:
         print(50)
     with open(sys.argv[4], 'w+') as f:
-        print(response['feedback'], file=f)
+        print(result['feedback'], file=f)
 
     sys.exit(0)
 ==


### PR DESCRIPTION
Every opened file in `graderCpp.py` are now opened inside a `with` statement, so that they are closed immediately without waiting for the garbage collector.

Also fixed a little mistake in wims.pl.